### PR TITLE
Update Cargo.toml add repository

### DIFF
--- a/proc-macros/Cargo.toml
+++ b/proc-macros/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Jonas Møller <jonas@nimda.no>"]
 edition = "2021"
 description = "Procedural macros for SPAIK"
 license = "BSD-2-Clause"
+repository = "https://github.com/snyball/spaik"
 
 [lib]
 name = "spaik_proc_macros"


### PR DESCRIPTION
to allow crates.io, rust-digger and others to link to it